### PR TITLE
dismiss progress dialog on error

### DIFF
--- a/app/src/main/java/com/google/android/apps/watchme/MainActivity.java
+++ b/app/src/main/java/com/google/android/apps/watchme/MainActivity.java
@@ -322,6 +322,7 @@ public class MainActivity extends Activity implements
         protected void onPostExecute(
                 List<EventData> fetchedEvents) {
             if (fetchedEvents == null) {
+                progressDialog.dismiss();
                 return;
             }
 


### PR DESCRIPTION
onPostExecute returned without closing progress dialog when
fetchedevents was null
